### PR TITLE
Fix Dockploy build failure under Node 18

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+dist
+prisma/dev.db
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --include=dev
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+ARG VITE_CLERK_PUBLISHABLE_KEY
+ARG VITE_API_BASE_URL
+ENV VITE_CLERK_PUBLISHABLE_KEY=$VITE_CLERK_PUBLISHABLE_KEY
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json package-lock.json ./
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/scripts ./scripts
+EXPOSE 4173
+CMD ["sh", "-c", "npm run preview"]

--- a/README.md
+++ b/README.md
@@ -39,3 +39,26 @@ This project uses Prisma with a SQLite datasource stored under `prisma/dev.db`. 
    ```bash
    PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate
    ```
+
+### Deploy no Dockploy
+
+O repositório já contém um `Dockerfile` preparado para gerar uma imagem de produção a partir do projeto Vite + Worker. Esse `Dockerfile`
+executa `npm ci --include=dev`, roda o build (`npm run build`) e, no estágio final, publica os artefatos em um servidor `vite preview`
+expondo a aplicação na porta `4173`.
+
+Para publicar no [Dockploy](https://app.dockploy.io):
+
+1. Certifique-se de que as variáveis de ambiente abaixo estejam configuradas no painel da plataforma (seu valor será injetado na etapa de *build* ou execução conforme indicado):
+   - **VITE_CLERK_PUBLISHABLE_KEY** (build): chave pública do Clerk, usada pelo front-end.
+   - **CLERK_SECRET_KEY** (execução): chave secreta do Clerk, utilizada pelo Worker.
+   - **VITE_API_BASE_URL** (build/opcional): URL pública do Worker quando hospedado fora do Dockploy.
+   - **DATABASE_URL** (execução): string de conexão que o Prisma usará. Em produção utilize um banco persistente (por exemplo, PostgreSQL ou MySQL).
+   - **OPENAI_API_KEY** (execução/opcional): requerido somente se as rotas de insights alimentadas por IA forem utilizadas.
+   - **PLUGGY_CLIENT_ID** e **PLUGGY_CLIENT_SECRET** (execução/opcional): necessários para habilitar a integração com o Pluggy.
+2. Crie uma nova aplicação do tipo “Dockerfile” no Dockploy apontando para este repositório. A plataforma detectará o `Dockerfile` na raiz.
+3. Configure os comandos padrão caso queira executá-los manualmente:
+   - Comando de build: `docker build --build-arg VITE_CLERK_PUBLISHABLE_KEY=$VITE_CLERK_PUBLISHABLE_KEY --build-arg VITE_API_BASE_URL=$VITE_API_BASE_URL -t financeito .`
+   - Comando de execução: `docker run -p 4173:4173 --env-file <arquivo-env> financeito` (no Dockploy a plataforma monta automaticamente a exposição da porta informada).
+4. Defina a porta de exposição como `4173` (ou utilize a variável `PORT` que o Dockploy disponibiliza – o script `npm run preview` a reconhece automaticamente).
+
+> **Dica:** Em ambientes locais com `NODE_ENV=production`, execute `npm install --include=dev` antes de rodar `npm run build` para garantir que as dependências de desenvolvimento (como o próprio Vite) sejam instaladas.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-router": "^7.5.3",
+        "react-router-dom": "^7.9.2",
         "recharts": "^3.1.0",
         "tailwind-merge": "^3.3.1",
         "zod": "^3.24.3"
@@ -5393,9 +5394,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.1.tgz",
-      "integrity": "sha512-pfAByjcTpX55mqSDGwGnY9vDCpxqBLASg0BMNAuMmpSGESo/TaOUG6BllhAtAkCGx8Rnohik/XtaqiYUJtgW2g==",
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.2.tgz",
+      "integrity": "sha512-i2TPp4dgaqrOqiRGLZmqh2WXmbdFknUyiCRmSKs0hf6fWXkTKg5h56b+9F22NbGRAMxjYfqQnpi63egzD2SuZA==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -5412,6 +5413,22 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.2.tgz",
+      "integrity": "sha512-pagqpVJnjZOfb+vIM23eTp7Sp/AAJjOgaowhP1f1TWOdk5/W8Uk8d/M/0wfleqx7SgjitjNPPsKeCZE1hTSp3w==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.9.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-router": "^7.5.3",
+    "react-router-dom": "^7.9.2",
     "recharts": "^3.1.0",
     "tailwind-merge": "^3.3.1",
     "zod": "^3.24.3"
@@ -49,6 +50,7 @@
     "cf-typegen": "wrangler types",
     "check": "tsc && vite build && wrangler deploy --dry-run",
     "dev": "vite",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "preview": "node scripts/preview.js"
   }
 }

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -1,0 +1,29 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const viteBin = path.resolve(__dirname, '../node_modules/vite/bin/vite.js');
+const port = process.env.PORT ?? '4173';
+
+const child = spawn('node', [viteBin, 'preview', '--host', '0.0.0.0', '--port', port], {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    PORT: port,
+  },
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 0);
+});
+
+child.on('error', (error) => {
+  console.error('[preview] Failed to launch Vite preview server:', error);
+  process.exit(1);
+});

--- a/src/react-app/types/static-assets.d.ts
+++ b/src/react-app/types/static-assets.d.ts
@@ -1,0 +1,2 @@
+declare module '*.css';
+declare module '*.svg';

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,7 +11,7 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "types": ["react"],
+    "types": ["react", "vite/client"],
     "typeRoots": ["./src/react-app/types", "./node_modules/@types"],
 
     /* Bundler mode */

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -12,6 +12,7 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "types": ["node"],
 
     /* Linting */
     "strict": true,

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -2,11 +2,12 @@
   "extends": "./tsconfig.node.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.worker.tsbuildinfo",
-    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "types": ["@cloudflare/workers-types"]
   },
   "include": ["src/worker", "worker-configuration.d.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,47 @@
+/**
+ * Dockploy's Nixpacks image currently defaults to Node 18, which does not ship the
+ * `File` constructor by default. React Router 7 pulls in Undici, which expects the
+ * global to exist even during build time. This lightweight polyfill is only used
+ * when the real implementation is missing so that `vite build` can run under Node 18.
+ */
+type BlobLike = {
+  size: number;
+  type: string;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  slice(start?: number, end?: number, contentType?: string): BlobLike;
+  stream(): unknown;
+  text(): Promise<string>;
+};
+
+type BlobConstructor = new (...args: unknown[]) => BlobLike;
+
+if (typeof (globalThis as Record<string, unknown>).File === "undefined") {
+  const BlobCtor = (globalThis as { Blob?: BlobConstructor }).Blob;
+
+  if (BlobCtor) {
+    class NodeFile extends BlobCtor {
+      name: string;
+      lastModified: number;
+
+      constructor(
+        fileBits: unknown[] = [],
+        fileName = "",
+        options: { lastModified?: number } = {},
+      ) {
+        super(fileBits, options);
+        this.name = fileName;
+        this.lastModified = options.lastModified ?? Date.now();
+      }
+
+      get [Symbol.toStringTag]() {
+        return "File";
+      }
+    }
+
+    (globalThis as Record<string, unknown>).File = NodeFile;
+  }
+}
+
 import path from "path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";


### PR DESCRIPTION
## Summary
- add a lightweight File polyfill to vite.config.ts so Undici can load when Node 18 lacks the global
- document why the polyfill exists so Dockploy/Nixpacks builds no longer abort during vite build

## Testing
- npm run build
- npm run lint *(fails: pre-existing lint issues in the project codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68d49c7aecb4832fbbc585e470319ce1