### PR TITLE
Fix Vite config polyfill ordering for Node 18 builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,9 @@
-import "./vite.polyfills.js";
+await import("./vite.polyfills.js");
 import path from "path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import { cloudflare } from "@cloudflare/vite-plugin";
+
+const { cloudflare } = await import("@cloudflare/vite-plugin");
 
 export default defineConfig({
   plugins: [react(), cloudflare()],

--- a/vite.polyfills.ts
+++ b/vite.polyfills.ts
@@ -14,11 +14,6 @@ type BlobLike = {
 
 type BlobConstructor = new (...args: unknown[]) => BlobLike;
 
-declare global {
-  // eslint-disable-next-line no-var
-  var File: unknown;
-}
-
 if (typeof (globalThis as { File?: unknown }).File === "undefined") {
   const BlobCtor = (globalThis as { Blob?: BlobConstructor }).Blob;
 


### PR DESCRIPTION
## Summary
- ensure the build polyfill runs before loading the Cloudflare Vite plugin so Node 18 has a File constructor
- clean up the TypeScript polyfill so it no longer redeclares File when newer Node types are present

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4bf0ae95c832f80643371b72bbc21