### PR TITLE
Fix Pluggy connection save for missing connector name

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1811,9 +1811,9 @@ app.post('/api/pluggy/add-connection', authMiddleware, async (c) => {
     `);
     
     await insertStmt.bind(
-      userId, 
-      itemId.trim(), 
-      item.connector.name || 'Unknown Institution', 
+      userId,
+      itemId.trim(),
+      item.connector?.name?.trim() || item.clientUserId || 'Unknown Institution',
       item.status || 'CONNECTED'
     ).run();
 


### PR DESCRIPTION
## Summary
- ensure adding a Pluggy connection tolerates missing connector metadata by falling back to other identifiers before inserting

## Testing
- `npm run lint` *(fails: existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d1e15a2c832fb9c948ee974c405d