### PR TITLE
Improve API base URL handling

### DIFF
--- a/src/react-app/utils/api.ts
+++ b/src/react-app/utils/api.ts
@@ -1,6 +1,31 @@
 const rawBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim();
-const normalizedBaseUrl = rawBaseUrl ? rawBaseUrl.replace(/\/+$/, '') : '';
-const isAbsoluteBaseUrl = normalizedBaseUrl.startsWith('http://') || normalizedBaseUrl.startsWith('https://');
+const sanitizedBaseUrl = rawBaseUrl ? rawBaseUrl.replace(/\/+$/, '') : '';
+
+const looksLikeHost = (value: string) => {
+  const trimmed = value.replace(/^\/+/, '');
+  return /[a-z0-9-]+\.[a-z0-9.-]+/i.test(trimmed);
+};
+
+const ensureScheme = (value: string) => {
+  if (!value) {
+    return '';
+  }
+
+  if (/^https?:\/\//i.test(value) || value.startsWith('//')) {
+    return value;
+  }
+
+  if (looksLikeHost(value)) {
+    const withoutLeadingSlashes = value.replace(/^\/+/, '');
+    return `https://${withoutLeadingSlashes}`;
+  }
+
+  return value;
+};
+
+const normalizedBaseUrl = ensureScheme(sanitizedBaseUrl);
+const isAbsoluteBaseUrl = /^https?:\/\//i.test(normalizedBaseUrl) || normalizedBaseUrl.startsWith('//');
+const isRelativeBaseUrl = !isAbsoluteBaseUrl && normalizedBaseUrl.startsWith('/');
 
 function buildUrl(path: string): string {
   if (/^https?:\/\//i.test(path)) {
@@ -13,7 +38,23 @@ function buildUrl(path: string): string {
     return normalizedPath;
   }
 
-  return `${normalizedBaseUrl}${normalizedPath}`;
+  if (isAbsoluteBaseUrl) {
+    const baseWithTrailingSlash = normalizedBaseUrl.endsWith('/')
+      ? normalizedBaseUrl
+      : `${normalizedBaseUrl}/`;
+    const relativePath = normalizedPath.replace(/^\/+/, '');
+    return `${baseWithTrailingSlash}${relativePath}`;
+  }
+
+  if (isRelativeBaseUrl) {
+    const baseWithoutTrailingSlash = normalizedBaseUrl.replace(/\/+$/, '');
+    if (normalizedPath.startsWith(`${baseWithoutTrailingSlash}/`)) {
+      return normalizedPath;
+    }
+    return `${baseWithoutTrailingSlash}${normalizedPath}`;
+  }
+
+  return normalizedPath;
 }
 
 export function apiFetch(path: string, init?: RequestInit) {


### PR DESCRIPTION
## Summary
- treat host-like VITE_API_BASE_URL values (even when written as root-relative) as HTTPS URLs automatically
- refine relative base URL joining logic to avoid duplicating path prefixes and ensure correct absolute request URLs

## Testing
- npm run lint *(fails: longstanding lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d3f6ff08832fa1f88f886182d21e