### PR TITLE
Fix Pluggy config persistence

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1826,12 +1826,11 @@ app.post('/api/pluggy/config', authMiddleware, async (c) => {
   }
 
   try {
-    const statements = [
-      upsertUserConfigValue(c.env.DB, userId, 'pluggy_client_id', clientId),
-      upsertUserConfigValue(c.env.DB, userId, 'pluggy_client_secret', clientSecret)
-    ];
+    const clientIdStatement = upsertUserConfigValue(c.env.DB, userId, 'pluggy_client_id', clientId);
+    const clientSecretStatement = upsertUserConfigValue(c.env.DB, userId, 'pluggy_client_secret', clientSecret);
 
-    await c.env.DB.batch(statements);
+    await clientIdStatement.run();
+    await clientSecretStatement.run();
 
     return Response.json({ success: true, clientId, clientSecret });
   } catch (error) {


### PR DESCRIPTION
## Summary
- ensure Pluggy configuration entries are written individually instead of via batch execution to avoid persistence failures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2fedae890832f89c2a9129e128587