### PR TITLE
Handle production Pluggy API host routing

### DIFF
--- a/src/react-app/utils/api.ts
+++ b/src/react-app/utils/api.ts
@@ -1,6 +1,11 @@
 const rawBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim();
 const sanitizedBaseUrl = rawBaseUrl ? rawBaseUrl.replace(/\/+$/, '') : '';
 
+const PRODUCTION_FALLBACKS: Record<string, string> = {
+  'contas.ramonma.online': 'https://n5jcegoubmvau.mocha.app',
+  'fincontas.ramonma.online': 'https://n5jcegoubmvau.mocha.app',
+};
+
 const ensureScheme = (value: string) => {
   if (!value) {
     return '';
@@ -13,7 +18,22 @@ const ensureScheme = (value: string) => {
   return `https://${value}`;
 };
 
-const normalizedBaseUrl = ensureScheme(sanitizedBaseUrl);
+const normalizedBaseUrl = (() => {
+  const explicit = ensureScheme(sanitizedBaseUrl);
+
+  if (explicit) {
+    return explicit;
+  }
+
+  if (typeof window !== 'undefined') {
+    const fallback = PRODUCTION_FALLBACKS[window.location.hostname.toLowerCase()];
+    if (fallback) {
+      return ensureScheme(fallback.replace(/\/+$/, ''));
+    }
+  }
+
+  return '';
+})();
 const isAbsoluteBaseUrl = /^https?:\/\//i.test(normalizedBaseUrl) || normalizedBaseUrl.startsWith('//');
 const isRelativeBaseUrl = normalizedBaseUrl.startsWith('/');
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -128,7 +128,12 @@ app.use('*', async (c, next) => {
 
 // Enhanced CORS configuration
 app.use('*', cors({
-  origin: ['https://n5jcegoubmvau.mocha.app', 'http://localhost:5173', 'https://contas.ramonma.online'],
+  origin: [
+    'https://n5jcegoubmvau.mocha.app',
+    'http://localhost:5173',
+    'https://contas.ramonma.online',
+    'https://fincontas.ramonma.online',
+  ],
   allowHeaders: ['Content-Type', 'Authorization'],
   allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   credentials: true,
@@ -1826,12 +1831,11 @@ app.post('/api/pluggy/config', authMiddleware, async (c) => {
   }
 
   try {
-    const statements = [
-      upsertUserConfigValue(c.env.DB, userId, 'pluggy_client_id', clientId),
-      upsertUserConfigValue(c.env.DB, userId, 'pluggy_client_secret', clientSecret)
-    ];
+    const clientIdStatement = upsertUserConfigValue(c.env.DB, userId, 'pluggy_client_id', clientId);
+    const clientSecretStatement = upsertUserConfigValue(c.env.DB, userId, 'pluggy_client_secret', clientSecret);
 
-    await c.env.DB.batch(statements);
+    await clientIdStatement.run();
+    await clientSecretStatement.run();
 
     return Response.json({ success: true, clientId, clientSecret });
   } catch (error) {


### PR DESCRIPTION
## Summary
- add production host fallbacks in the client API helper so the Pluggy requests target the Worker
- allow the fincontas.ramonma.online origin in the Worker's CORS policy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2fedae890832f89c2a9129e128587